### PR TITLE
fix: RudderstackOperator not waiting for sync completion

### DIFF
--- a/rudder_airflow_provider/operators/rudderstack.py
+++ b/rudder_airflow_provider/operators/rudderstack.py
@@ -1,3 +1,4 @@
+import logging
 from airflow.models import baseoperator
 from rudder_airflow_provider.hooks.rudderstack import RudderstackHook
 
@@ -25,6 +26,7 @@ class RudderstackOperator(baseoperator.BaseOperator):
         '''
         rs_hook = RudderstackHook(
             connection_id=self.connection_id, source_id=self.source_id)
-        rs_hook.trigger_sync()
-        if self.wait_for_completion:
-            rs_hook.poll_for_status()
+        run_id = rs_hook.trigger_sync()
+        if self.wait_for_completion and run_id is not None:
+            logging.info('waiting for sync to complete for sourceId: %s, runId: %s', self.source_id, run_id)
+            rs_hook.poll_for_status(run_id)

--- a/rudder_airflow_provider/test/operators/test_rudderstack_operator.py
+++ b/rudder_airflow_provider/test/operators/test_rudderstack_operator.py
@@ -10,7 +10,7 @@ class TestRudderstackOperator(unittest.TestCase):
     @mock.patch('rudder_airflow_provider.operators.rudderstack.RudderstackHook.trigger_sync')
     def test_operator_trigger_sync_without_wait(self, mock_hook_sync: mock.Mock, 
         mock_poll_status: mock.Mock):
-        mock_hook_sync.return_value = None
+        mock_hook_sync.return_value = 'some-run-id'
         operator = RudderstackOperator(source_id='some-source-id', 
             wait_for_completion=False, task_id='some-task-id')
         operator.execute(context=None)
@@ -21,14 +21,24 @@ class TestRudderstackOperator(unittest.TestCase):
     @mock.patch('rudder_airflow_provider.operators.rudderstack.RudderstackHook.trigger_sync')
     def test_operator_trigger_sync_with_wait(self, mock_hook_sync: mock.Mock, 
         mock_poll_status: mock.Mock):
-        mock_hook_sync.return_value = None
+        mock_hook_sync.return_value = 'some-run-id'
         mock_poll_status.return_value = None
         operator = RudderstackOperator(source_id='some-source-id',
             wait_for_completion=True, task_id='some-task-id')
         operator.execute(context=None)
         mock_hook_sync.assert_called_once()
         mock_poll_status.assert_called_once()
-
+    
+    # checks if poll_for_status is not called if run_id is None (possible if sync is already running)
+    @mock.patch('rudder_airflow_provider.operators.rudderstack.RudderstackHook.poll_for_status')
+    @mock.patch('rudder_airflow_provider.operators.rudderstack.RudderstackHook.trigger_sync')
+    def test_operator_no_polling_if_run_not_started(self, mock_hook_sync: mock.Mock, mock_poll_status: mock.Mock):
+        operator = RudderstackOperator(source_id='some-source-id',
+            wait_for_completion=True, task_id='some-task-id')
+        mock_hook_sync.return_value = None
+        operator.execute(context=None)
+        mock_hook_sync.assert_called_once()
+        mock_poll_status.assert_not_called()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Test Run Logs
```
/Users/yeshwanth/rudder/rudder-airflow-provider/examples/sample_dag.py:17 RemovedInAirflow3Warning: Param `schedule_interval` is deprecated and will be removed in a future release. Please use `schedule` instead.
[2024-02-22T18:59:35.378+0530] {dag.py:4069} INFO - dagrun id: rudderstack-sample
[2024-02-22T18:59:35.385+0530] {dag.py:4085} INFO - created dagrun <DagRun rudderstack-sample @ 2024-02-22 13:29:35.290528+00:00: manual__2024-02-22T13:29:35.290528+00:00, state:running, queued_at: None. externally triggered: False>
[2024-02-22T18:59:35.394+0530] {dag.py:4031} INFO - [DAG TEST] starting task_id=e2e-test map_index=-1
[2024-02-22T18:59:35.395+0530] {dag.py:4034} INFO - [DAG TEST] running task <TaskInstance: rudderstack-sample.e2e-test manual__2024-02-22T13:29:35.290528+00:00 [scheduled]>
[2024-02-22 18:59:35,604] {taskinstance.py:2480} INFO - Exporting env vars: AIRFLOW_CTX_DAG_EMAIL='airflow@example.com' AIRFLOW_CTX_DAG_OWNER='airflow' AIRFLOW_CTX_DAG_ID='rudderstack-sample' AIRFLOW_CTX_TASK_ID='e2e-test' AIRFLOW_CTX_EXECUTION_DATE='2024-02-22T13:29:35.290528+00:00' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2024-02-22T13:29:35.290528+00:00'
[2024-02-22T18:59:35.604+0530] {taskinstance.py:2480} INFO - Exporting env vars: AIRFLOW_CTX_DAG_EMAIL='airflow@example.com' AIRFLOW_CTX_DAG_OWNER='airflow' AIRFLOW_CTX_DAG_ID='rudderstack-sample' AIRFLOW_CTX_TASK_ID='e2e-test' AIRFLOW_CTX_EXECUTION_DATE='2024-02-22T13:29:35.290528+00:00' AIRFLOW_CTX_TRY_NUMBER='1' AIRFLOW_CTX_DAG_RUN_ID='manual__2024-02-22T13:29:35.290528+00:00'
[2024-02-22T18:59:35.609+0530] {base.py:83} INFO - Using connection ID 'rudderstack_default' for task execution.
[2024-02-22T18:59:35.610+0530] {rudderstack.py:30} INFO - triggering sync for sourceId: 2Ty4btEqKqV0OOIrWSTzlEjcrfI, endpoint: /v2/sources/2Ty4btEqKqV0OOIrWSTzlEjcrfI/start
[2024-02-22T18:59:35.611+0530] {base.py:83} INFO - Using connection ID 'rudderstack_default' for task execution.
[2024-02-22T18:59:36.797+0530] {rudderstack.py:35} INFO - Job triggered for sourceId: 2Ty4btEqKqV0OOIrWSTzlEjcrfI
[2024-02-22T18:59:36.798+0530] {rudderstack.py:31} INFO - waiting for sync to complete for sourceId: 2Ty4btEqKqV0OOIrWSTzlEjcrfI, runId: cnbkog022t1tus54psfg
[2024-02-22T18:59:36.800+0530] {base.py:83} INFO - Using connection ID 'rudderstack_default' for task execution.
[2024-02-22T18:59:36.802+0530] {base.py:83} INFO - Using connection ID 'rudderstack_default' for task execution.
[2024-02-22T18:59:37.938+0530] {rudderstack.py:52} INFO - sync status for sourceId: 2Ty4btEqKqV0OOIrWSTzlEjcrfI, runId: cnbkog022t1tus54psfg, status: running
[2024-02-22T19:00:37.960+0530] {base.py:83} INFO - Using connection ID 'rudderstack_default' for task execution.
[2024-02-22T19:00:39.140+0530] {rudderstack.py:52} INFO - sync status for sourceId: 2Ty4btEqKqV0OOIrWSTzlEjcrfI, runId: cnbkog022t1tus54psfg, status: finished
[2024-02-22T19:00:39.140+0530] {rudderstack.py:60} INFO - sync finished for sourceId: 2Ty4btEqKqV0OOIrWSTzlEjcrfI, runId: cnbkog022t1tus54psfg
[2024-02-22T19:00:39.147+0530] {taskinstance.py:1138} INFO - Marking task as SUCCESS. dag_id=rudderstack-sample, task_id=e2e-test, execution_date=20240222T132935, start_date=, end_date=20240222T133039
[2024-02-22T19:00:39.163+0530] {dag.py:4045} INFO - [DAG TEST] end task task_id=e2e-test map_index=-1
[2024-02-22T19:00:39.173+0530] {dagrun.py:732} INFO - Marking run <DagRun rudderstack-sample @ 2024-02-22 13:29:35.290528+00:00: manual__2024-02-22T13:29:35.290528+00:00, state:running, queued_at: None. externally triggered: False> successful
[2024-02-22T19:00:39.174+0530] {dagrun.py:783} INFO - DagRun Finished: dag_id=rudderstack-sample, execution_date=2024-02-22 13:29:35.290528+00:00, run_id=manual__2024-02-22T13:29:35.290528+00:00, run_start_date=2024-02-22 13:29:35.290528+00:00, run_end_date=2024-02-22 13:30:39.174296+00:00, run_duration=63.883768, state=success, external_trigger=False, run_type=manual, data_interval_start=2024-02-21 13:29:35.290528+00:00, data_interval_end=2024-02-22 13:29:35.290528+00:00, dag_hash=None
```