### PR TITLE
feat: operator for retl syncs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ pip install rudderstack-airflow-provider
 
 ## Usage
 
+### RudderstackOperator
+
+> [!NOTE]  
+> Use [RudderstackRETLOperator](#rudderstackretloperator) for reverse ETL connections
+
 A simple DAG for triggering syncs for a RudderStack source:
 
 ```python
@@ -54,10 +59,10 @@ with DAG(
 
 For the complete code, refer to this [example](https://github.com/rudderlabs/rudder-airflow-provider/blob/main/examples/sample_dag.py).
 
-### Operator Parameters
+#### Operator Parameters
 
 | Parameter | Description | Type | Default |
-| :--- |:--- | :--- | :--- |
+| :--- |:--- | :--- | :--- 
 | `source_id` | Valid RudderStack source ID | String | `None` |
 | `task_id` | A unique task ID within a DAG | String | `None` |
 | `wait_for_completion` | If `True`, the task will wait for sync to complete. | Boolean | `False` |
@@ -66,6 +71,41 @@ For the complete code, refer to this [example](https://github.com/rudderlabs/rud
 The RudderStack operator also supports all the parameters supported by the [Airflow base operator](https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/baseoperator/index.html).
 
 For details on how to run the DAG in Airflow, refer to the [documentation](https://www.rudderstack.com/docs/reverse-etl/features/airflow-provider/#running-the-dag).
+
+### RudderstackRETLOperator
+
+Trigger syncs for RETL connections
+
+```python
+with DAG('rudderstack-sample',
+    default_args=default_args,
+    description='A simple tutorial DAG',
+    schedule_interval=timedelta(days=1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    tags=['rs']) as dag:
+    rs_operator = RudderstackRETLOperator(
+        retl_connection_id='2aiDQzMqP6LNuUokWstmaubcZOP',
+        task_id='retl-test-sync',
+        connection_id='rudder_yeshwanth_dev',
+        sync_type='full',
+        wait_for_completion=True
+    )
+```
+
+#### Operator parameters
+
+| Parameter | Description | Type | Default |
+| :--- |:--- | :--- | :--- 
+| `retl_connection_id` | Valid RudderStack RETL connection ID | String | `None` |
+| `task_id` | A unique task ID within a DAG | String | `None` |
+| `wait_for_completion` | If `True`, the task will wait for sync to complete. | Boolean | `False` |
+| `connection_id` | The Airflow connection to use for connecting to the Rudderstack API. | String | `rudderstack_default` |
+|`sync_type`| Type of sync to trigger | `incremental` or `full`| `incremntal`|
+
+
+For details on how to run the DAG in Airflow, refer to the [documentation](https://www.rudderstack.com/docs/reverse-etl/features/airflow-provider/#running-the-dag).
+
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ with DAG('rudderstack-sample',
 
 | Parameter | Description | Type | Default |
 | :--- |:--- | :--- | :--- 
-| `retl_connection_id` | Valid RudderStack RETL connection ID | String | `None` |
+| `retl_connection_id` | Valid RudderStack RETL connection ID | String (templatable) | `None` |
 | `task_id` | A unique task ID within a DAG | String | `None` |
 | `wait_for_completion` | If `True`, the task will wait for sync to complete. | Boolean | `False` |
 | `connection_id` | The Airflow connection to use for connecting to the Rudderstack API. | String | `rudderstack_default` |
-|`sync_type`| Type of sync to trigger | `incremental` or `full`| `incremntal`|
+|`sync_type`| Type of sync to trigger | `incremental` or `full` (templatable) | `incremntal`|
 
 
 For details on how to run the DAG in Airflow, refer to the [documentation](https://www.rudderstack.com/docs/reverse-etl/features/airflow-provider/#running-the-dag).

--- a/examples/retl_sample.dag.py
+++ b/examples/retl_sample.dag.py
@@ -21,6 +21,7 @@ with DAG('rudderstack-sample',
     start_date=datetime(2021, 1, 1),
     catchup=False,
     tags=['rs']) as dag:
+    # retl_connection_id, sync_type are template fields
     rs_operator = RudderstackRETLOperator(
         retl_connection_id="{{ var.value.retl_connection_id }}",
         task_id='<replace task id>',

--- a/examples/retl_sample.dag.py
+++ b/examples/retl_sample.dag.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+
+from airflow import DAG
+
+from rudder_airflow_provider.operators.rudderstack import RudderstackRETLOperator
+
+default_args = {
+    'owner': 'airflow',
+    'depends_on_past': False,
+    'email': ['airflow@example.com'],
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5)
+}
+
+with DAG('rudderstack-sample',
+    default_args=default_args,
+    description='A simple tutorial DAG',
+    schedule_interval=timedelta(days=1),
+    start_date=datetime(2021, 1, 1),
+    catchup=False,
+    tags=['rs']) as dag:
+    rs_operator = RudderstackRETLOperator(
+        retl_connection_id='2aiDQzMqP6LNuUokWstmaubcZOP',
+        task_id='retl-test-sync',
+        connection_id='rudder_yeshwanth_dev',
+        sync_type='full',
+        wait_for_completion=True
+    )
+
+if __name__ == "__main__":
+    dag.test()

--- a/examples/retl_sample.dag.py
+++ b/examples/retl_sample.dag.py
@@ -22,10 +22,10 @@ with DAG('rudderstack-sample',
     catchup=False,
     tags=['rs']) as dag:
     rs_operator = RudderstackRETLOperator(
-        retl_connection_id='2aiDQzMqP6LNuUokWstmaubcZOP',
-        task_id='retl-test-sync',
-        connection_id='rudder_yeshwanth_dev',
-        sync_type='full',
+        retl_connection_id="{{ var.value.retl_connection_id }}",
+        task_id='<replace task id>',
+        connection_id='<rudderstack api connection id>',
+        sync_type="{{ var.value.sync_type }}",
         wait_for_completion=True
     )
 

--- a/rudder_airflow_provider/hooks/rudderstack.py
+++ b/rudder_airflow_provider/hooks/rudderstack.py
@@ -1,63 +1,69 @@
+from enum import Enum
 import logging
 import time
 
 from airflow.exceptions import AirflowException
 from airflow.providers.http.hooks.http import HttpHook
+import requests
 
 STATUS_FINISHED = 'finished'
-STATUS_POLL_INTERVAL = 60
+STATUS_POLL_INTERVAL = 10
 
+class RETLSyncStatus(Enum):
+    '''
+        Enum for retl sync status
+    '''
+    RUNNING = 'running'
+    SUCCEEDED = 'succeeded'
+    FAILED = 'failed'
 
 class RudderstackHook(HttpHook):
     '''
         Hook for rudderstack public API
     '''
 
-    def __init__(self,  connection_id: str, source_id: str) -> None:
+    def __init__(self,  connection_id: str) -> None:
         self.connection_id = connection_id
-        if source_id is None:
-            raise AirflowException('source_id is mandatory')
-        self.source_id = source_id
         super().__init__(http_conn_id=self.connection_id)
 
-    def trigger_sync(self) -> str | None:
+    def trigger_sync(self, source_id:str) -> str | None:
         '''
             trigger sync for a source
         '''
         self.method = 'POST'
-        sync_endpoint = f"/v2/sources/{self.source_id}/start"
+        sync_endpoint = f"/v2/sources/{source_id}/start"
         headers = self.get_request_headers()
         logging.info('triggering sync for sourceId: %s, endpoint: %s',
-                     self.source_id, sync_endpoint)
+                     source_id, sync_endpoint)
         resp = self.run(endpoint=sync_endpoint, headers=headers,
             extra_options={"check_response": False})
         if resp.status_code in (200, 204, 201):
-            logging.info('Job triggered for sourceId: %s', self.source_id)
+            logging.info('Job triggered for sourceId: %s', source_id)
             return resp.json().get('runId')
         elif resp.status_code == 409:
-            logging.info('Job is already running for sourceId: %s', self.source_id)
+            logging.info('Job is already running for sourceId: %s', source_id)
         else:
-            raise AirflowException(f"Error while starting sync for sourceId: {self.source_id}, response: {resp.status_code}")
+            raise AirflowException(f"Error while starting sync for sourceId: {source_id}, response: {resp.status_code}")
 
-    def poll_for_status(self, run_id: str):
+    def poll_for_status(self, source_id, run_id: str):
         '''
             polls for sync status
         '''
-        status_endpoint = f"/v2/sources/{self.source_id}/runs/{run_id}/status"
+        status_endpoint = f"/v2/sources/{source_id}/runs/{run_id}/status"
         headers = self.get_request_headers()
         while True:
             self.method = 'GET'
             resp = self.run(endpoint=status_endpoint, headers=headers).json()
             job_status = resp['status']
             logging.info('sync status for sourceId: %s, runId: %s, status: %s',
-                         self.source_id, run_id, job_status)
+                         source_id, run_id, job_status)
 
             if job_status == STATUS_FINISHED:
                 if resp.get('error'):
                     raise AirflowException(
-                        f"sync for sourceId: {self.source_id} failed with error: {resp['error']}")
+                        f"sync for sourceId: {source_id} failed with error: {resp['error']}")
 
-                logging.info('sync finished for sourceId: %s, runId: %s', self.source_id, run_id)
+                logging.info('sync finished for sourceId: %s, runId: %s', source_id, run_id)
                 break
             time.sleep(STATUS_POLL_INTERVAL)
 
@@ -74,3 +80,50 @@ class RudderstackHook(HttpHook):
         '''
         conn = self.get_connection(self.connection_id)
         return conn.password
+
+    def get_api_base_url(self):
+        '''
+            returns base api url
+        '''
+        conn = self.get_connection(self.connection_id)
+        return conn.host
+
+    def trigger_retl_sync(self, retl_connection_id, sync_type: str):
+        '''
+            trigger sync for a retl source
+        '''
+        base_url = self.get_api_base_url().rstrip('/')
+        sync_endpoint = f"/v2/retl-connections/{retl_connection_id}/start"
+        headers = self.get_request_headers()
+        logging.info('triggering sync for retl connection, endpoint: %s', sync_endpoint)
+        sync_req_data = { "syncType": sync_type }
+        resp = requests.post(f"{base_url}{sync_endpoint}", json=sync_req_data, headers=headers)
+        if resp.status_code == 200:
+            logging.info('Job triggered for retl connection, syncId: %s', resp.json().get("syncId"))
+            return resp.json().get('syncId')
+        else:
+            error = resp.json().get('error', None)
+            raise AirflowException(f"Error while starting sync for retl, response: {resp.status_code}, error: {error}")
+    
+
+    def poll_retl_sync_status(self, retl_connection_id, sync_id: str):
+        '''
+            polls for retl sync status
+        '''
+        base_url = self.get_api_base_url().rstrip('/')
+        status_endpoint = f"/v2/retl-connections/{retl_connection_id}/syncs/{sync_id}"
+        headers = self.get_request_headers()
+        while True:
+            resp = requests.get(f"{base_url}{status_endpoint}", headers=headers)
+            if resp.status_code != 200:
+                error_msg = resp.json().get('error', None)
+                raise AirflowException(f"Error while fetching sync status for retl, status: {resp.status_code}, error: {error_msg}")
+            job_status = resp.json()['status']
+            logging.info('sync status for retl connection, sycId: %s, status: %s', sync_id, job_status)
+            if job_status == RETLSyncStatus.SUCCEEDED.value:
+                logging.info('sync finished for retl connection, syncId: %s', sync_id)
+                break
+            elif job_status == RETLSyncStatus.FAILED.value:
+                error_msg = resp.json().get('error', None)
+                raise AirflowException(f"sync for retl connection failed with error: {error_msg}")
+            time.sleep(STATUS_POLL_INTERVAL)

--- a/rudder_airflow_provider/operators/rudderstack.py
+++ b/rudder_airflow_provider/operators/rudderstack.py
@@ -29,6 +29,8 @@ class RudderstackOperator(baseoperator.BaseOperator):
 
 
 class RudderstackRETLOperator(baseoperator.BaseOperator):
+    template_fields = ('retl_connection_id', 'sync_type')
+    
     '''
         Rudderstack operator for RETL connnections
         :param retl_connection_id: unique id of the retl connection

--- a/rudder_airflow_provider/operators/rudderstack.py
+++ b/rudder_airflow_provider/operators/rudderstack.py
@@ -3,6 +3,10 @@ from airflow.models import baseoperator
 from rudder_airflow_provider.hooks.rudderstack import RudderstackHook
 
 RUDDERTACK_DEFAULT_CONNECTION_ID = 'rudderstack_default'
+RETL_SYNC_TYPE_FULL = 'full'
+RETL_SYNC_TYPE_INCREMENTAL = 'incremental'
+
+
 class RudderstackOperator(baseoperator.BaseOperator):
     '''
         Rudderstack operator for airflow DAGs
@@ -40,7 +44,7 @@ class RudderstackRETLOperator(baseoperator.BaseOperator):
     '''
     def __init__(self, 
                  retl_connection_id: str, 
-                 sync_type: str, 
+                 sync_type: str = 'incremental', 
                  connection_id: str = RUDDERTACK_DEFAULT_CONNECTION_ID,
                  wait_for_completion: bool = False,
                  **kwargs):

--- a/rudder_airflow_provider/operators/rudderstack.py
+++ b/rudder_airflow_provider/operators/rudderstack.py
@@ -2,14 +2,11 @@ import logging
 from airflow.models import baseoperator
 from rudder_airflow_provider.hooks.rudderstack import RudderstackHook
 
-
+RUDDERTACK_DEFAULT_CONNECTION_ID = 'rudderstack_default'
 class RudderstackOperator(baseoperator.BaseOperator):
     '''
         Rudderstack operator for airflow DAGs
     '''
-
-    RUDDERTACK_DEFAULT_CONNECTION_ID = 'rudderstack_default'
-
     def __init__(self, source_id: str, connection_id: str = RUDDERTACK_DEFAULT_CONNECTION_ID,
                  wait_for_completion: bool = False, **kwargs):
         '''
@@ -24,9 +21,39 @@ class RudderstackOperator(baseoperator.BaseOperator):
         '''
             Executes rudderstack operator
         '''
-        rs_hook = RudderstackHook(
-            connection_id=self.connection_id, source_id=self.source_id)
-        run_id = rs_hook.trigger_sync()
+        rs_hook = RudderstackHook(connection_id=self.connection_id)
+        run_id = rs_hook.trigger_sync(self.source_id)
         if self.wait_for_completion and run_id is not None:
             logging.info('waiting for sync to complete for sourceId: %s, runId: %s', self.source_id, run_id)
-            rs_hook.poll_for_status(run_id)
+            rs_hook.poll_for_status(self.source_id, run_id)
+
+
+class RudderstackRETLOperator(baseoperator.BaseOperator):
+    '''
+        Rudderstack operator for RETL connnections
+        :param retl_connection_id: unique id of the retl connection
+        :param sync_type: type of sync to trigger. Possible values are 'full' or 'incremental'
+        :param connection_id: airflow connection id for rudderstack API
+        :param wait_for_completion: wait for sync to complete. Default is False
+    '''
+    def __init__(self, 
+                 retl_connection_id: str, 
+                 sync_type: str, 
+                 connection_id: str = RUDDERTACK_DEFAULT_CONNECTION_ID,
+                 wait_for_completion: bool = False,
+                 **kwargs):
+        '''
+            Initialize rudderstack operator
+        '''
+        super().__init__(**kwargs)
+        self.wait_for_completion = wait_for_completion
+        self.connection_id = connection_id
+        self.retl_connection_id = retl_connection_id
+        self.sync_type = sync_type
+
+    def execute(self, context):
+        rs_hook = RudderstackHook(connection_id=self.connection_id)
+        sync_id = rs_hook.trigger_retl_sync(self.retl_connection_id, self.sync_type)
+        if self.wait_for_completion:
+            logging.info('waiting for sync to complete for retl-connecion: %s, syncId: %s', self.retl_connection_id, sync_id)
+            rs_hook.poll_retl_sync_status(self.retl_connection_id, sync_id)

--- a/rudder_airflow_provider/test/hooks/test_rudderstack_hook.py
+++ b/rudder_airflow_provider/test/hooks/test_rudderstack_hook.py
@@ -4,7 +4,7 @@ from airflow.exceptions import AirflowException
 
 from airflow.models.connection import Connection
 from requests.models import Response
-from rudder_airflow_provider.hooks.rudderstack import RudderstackHook
+from rudder_airflow_provider.hooks.rudderstack import STATUS_POLL_INTERVAL, RudderstackHook
 
 
 class RudderstackHookTest(unittest.TestCase):
@@ -13,7 +13,7 @@ class RudderstackHookTest(unittest.TestCase):
     def test_get_access_token(self, mocked_http: mock.Mock):
         rudder_connection = Connection(password='some-password')
         mocked_http.return_value = rudder_connection
-        hook = RudderstackHook('rudderstack_connection', '12345')
+        hook = RudderstackHook('rudderstack_connection')
         self.assertEqual(hook.get_access_token(), 'some-password')
 
     @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
@@ -21,14 +21,14 @@ class RudderstackHookTest(unittest.TestCase):
     def test_trigger_sync(self, mock_run: mock.Mock, mock_connection: mock.Mock):
         source_id = 'some-source-id'
         access_token = 'some-password'
-        hook = RudderstackHook('rudderstack_connection', source_id)
+        hook = RudderstackHook('rudderstack_connection')
         mock_connection.return_value = Connection(password=access_token)
         sync_endpoint = f"/v2/sources/{source_id}/start"
         start_resp = Response()
         start_resp.json = mock.MagicMock(return_value={'runId': 'some-run-id'})
         start_resp.status_code = 204
         mock_run.return_value = start_resp
-        run_id = hook.trigger_sync()
+        run_id = hook.trigger_sync(source_id)
         expected_headers = {
                  'authorization': f"Bearer {access_token}",
                  'Content-Type': 'application/json'
@@ -40,13 +40,13 @@ class RudderstackHookTest(unittest.TestCase):
     def test_trigger_sync_conflict_status(self, mock_run: mock.Mock, mock_connection: mock.Mock):
         source_id = 'some-source-id'
         access_token = 'some-password'
-        hook = RudderstackHook('rudderstack_connection', source_id)
+        hook = RudderstackHook('rudderstack_connection')
         mock_connection.return_value = Connection(password=access_token)
         sync_endpoint = f"/v2/sources/{source_id}/start"
         start_resp = Response()
         start_resp.status_code = 409
         mock_run.return_value = start_resp
-        run_id = hook.trigger_sync()
+        run_id = hook.trigger_sync(source_id)
         self.assertIsNone(run_id)
         expected_headers = {
                  'authorization': f"Bearer {access_token}",
@@ -59,13 +59,13 @@ class RudderstackHookTest(unittest.TestCase):
     def test_trigger_sync_error_status(self, mock_run: mock.Mock, mock_connection: mock.Mock):
         source_id = 'some-source-id'
         access_token = 'some-password'
-        hook = RudderstackHook('rudderstack_connection', source_id)
+        hook = RudderstackHook('rudderstack_connection')
         mock_connection.return_value = Connection(password=access_token)
         sync_endpoint = f"/v2/sources/{source_id}/start"
         start_resp = Response()
         start_resp.status_code = 500
         mock_run.return_value = start_resp
-        self.assertRaises(AirflowException, hook.trigger_sync)
+        self.assertRaises(AirflowException, hook.trigger_sync, source_id)
         expected_headers = {
                  'authorization': f"Bearer {access_token}",
                  'Content-Type': 'application/json'
@@ -79,8 +79,8 @@ class RudderstackHookTest(unittest.TestCase):
         access_token = 'some-password'
         mock_connection.return_value = Connection(password=access_token)
         mock_run.side_effect = AirflowException()
-        hook = RudderstackHook('rudderstack_connection', source_id)
-        self.assertRaises(AirflowException, hook.trigger_sync)
+        hook = RudderstackHook('rudderstack_connection')
+        self.assertRaises(AirflowException, hook.trigger_sync, source_id)
 
     @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
     @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.run')
@@ -94,8 +94,8 @@ class RudderstackHookTest(unittest.TestCase):
         finished_status_response.json = mock.MagicMock(return_value={'status': 'finished'})
         mock_run.return_value = finished_status_response
         mock_connection.return_value = Connection(password=access_token)
-        hook = RudderstackHook('rudderstack_connection', source_id)
-        hook.poll_for_status(run_id)
+        hook = RudderstackHook('rudderstack_connection')
+        hook.poll_for_status(source_id, run_id)
         expected_headers = {
                  'authorization': f"Bearer {access_token}",
                  'Content-Type': 'application/json'
@@ -115,14 +115,96 @@ class RudderstackHookTest(unittest.TestCase):
             return_value={'status': 'finished', 'error': 'some-eror'})
         mock_run.return_value = finished_status_response
         mock_connection.return_value = Connection(password=access_token)
-        hook = RudderstackHook('rudderstack_connection', source_id)
-        self.assertRaises(AirflowException, hook.poll_for_status, run_id)
+        hook = RudderstackHook('rudderstack_connection')
+        self.assertRaises(AirflowException, hook.poll_for_status, source_id, run_id)
         expected_headers = {
                  'authorization': f"Bearer {access_token}",
                  'Content-Type': 'application/json'
                  }
         mock_run.assert_called_once_with(endpoint=status_endpoint, headers=expected_headers)
 
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.requests.post')
+    def test_retl_trigger_sync(self, mock_post: mock.Mock, mock_connection: mock.Mock):
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {'syncId': 'some-sync-id'}
+        mock_connection.side_effect = [Connection(password='some-password', host='https://some-url.com'), Connection(password='some-password')]
+        retl_connection_id = 'some-connection-id'
+        sync_type = 'full'
+        base_url = 'https://some-url.com'
+        retl_sync_endpoint = f"/v2/retl-connections/{retl_connection_id}/start"
+        hook = RudderstackHook('rudderstack_connection')
+        sync_id = hook.trigger_retl_sync(retl_connection_id, sync_type)
+        self.assertEqual(sync_id, 'some-sync-id')
+        mock_post.assert_called_once_with(f"{base_url}{retl_sync_endpoint}", json={'syncType': sync_type},
+                                          headers={'authorization' : f"Bearer some-password", 'Content-Type': 'application/json'})
+        mock_connection.assert_called_with('rudderstack_connection')
+
+    # test 409 retl trigger sync and expect AirflowException
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.requests.post')
+    def test_retl_trigger_sync_conflict(self, mock_post: mock.Mock, mock_connection: mock.Mock):
+        mock_post.return_value.status_code = 409
+        mock_connection.side_effect = [Connection(password='some-password', host='https://some-url.com'), Connection(password='some-password')]
+        retl_connection_id = 'some-connection-id'
+        sync_type = 'full'
+        base_url = 'https://some-url.com'
+        retl_sync_endpoint = f"/v2/retl-connections/{retl_connection_id}/start"
+        hook = RudderstackHook('rudderstack_connection')
+        self.assertRaises(AirflowException, hook.trigger_retl_sync, retl_connection_id, sync_type)
+        mock_post.assert_called_once_with(f"{base_url}{retl_sync_endpoint}", json={'syncType': sync_type},
+                                          headers={'authorization' : f"Bearer some-password", 'Content-Type': 'application/json'})
+        mock_connection.assert_called_with('rudderstack_connection')
+
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.requests.get')
+    def test_poll_for_retl_sync_status(self, mock_get: mock.Mock, mock_connection: mock.Mock):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {'status': 'succeeded'}
+        mock_connection.side_effect = [Connection(password='some-password', host='https://some-url.com'), Connection(password='some-password')]
+        retl_connection_id = 'some-connection-id'
+        sync_id = 'some-sync-id'
+        base_url = 'https://some-url.com'
+        retl_sync_status_endpoint = f"/v2/retl-connections/{retl_connection_id}/syncs/{sync_id}"
+        hook = RudderstackHook('rudderstack_connection')
+        hook.poll_retl_sync_status(retl_connection_id, sync_id)
+        mock_get.assert_called_once_with(f"{base_url}{retl_sync_status_endpoint}", headers={'authorization' : f"Bearer some-password", 'Content-Type': 'application/json'})
+        mock_connection.assert_called_with('rudderstack_connection')
+    
+
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.requests.get')
+    def test_poll_for_retl_sync_status_failed(self, mock_get: mock.Mock, mock_connection: mock.Mock):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {'status': 'failed'}
+        mock_connection.side_effect = [Connection(password='some-password', host='https://some-url.com'), Connection(password='some-password')]
+        retl_connection_id = 'some-connection-id'
+        sync_id = 'some-sync-id'
+        base_url = 'https://some-url.com'
+        retl_sync_status_endpoint = f"/v2/retl-connections/{retl_connection_id}/syncs/{sync_id}"
+        hook = RudderstackHook('rudderstack_connection')
+        self.assertRaises(AirflowException, hook.poll_retl_sync_status, retl_connection_id, sync_id)
+        mock_get.assert_called_once_with(f"{base_url}{retl_sync_status_endpoint}", headers={'authorization' : f"Bearer some-password", 'Content-Type': 'application/json'})
+        mock_connection.assert_called_with('rudderstack_connection')
+
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.HttpHook.get_connection')
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.requests.get')
+    @mock.patch('rudder_airflow_provider.hooks.rudderstack.time.sleep')
+    def test_poll_for_retl_sync_status_running(self, mock_sleep: mock.Mock, mock_get: mock.Mock, mock_connection: mock.Mock):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.side_effect = [{'status': 'running'}, {'status': 'succeeded'}]
+        mock_connection.side_effect = [Connection(password='some-password', host='https://some-url.com'), Connection(password='some-password')]
+        retl_connection_id = 'some-connection-id'
+        sync_id = 'some-sync-id'
+        base_url = 'https://some-url.com'
+        retl_sync_status_endpoint = f"/v2/retl-connections/{retl_connection_id}/syncs/{sync_id}"
+        hook = RudderstackHook('rudderstack_connection')
+        hook.poll_retl_sync_status(retl_connection_id, sync_id)
+        mock_get.assert_called_with(f"{base_url}{retl_sync_status_endpoint}", headers={'authorization' : f"Bearer some-password", 'Content-Type': 'application/json'})
+        mock_connection.assert_called_with('rudderstack_connection')
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(mock_sleep.call_count, 1)
+        mock_sleep.assert_called_with(STATUS_POLL_INTERVAL)    
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,8 @@ python_requires >= 3.6
 packages = find:
 install_requires = 
     apache-airflow >= 2.5.3
-    apache-airflow-providers-http >= 4.0.0
-    requests >= 2.26.0
+    apache-airflow-providers-http >= 4.2.0
+    requests >= 2.28.2
 
 [options.packages.find]
 exclude= *test*

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,8 @@ python_requires >= 3.6
 packages = find:
 install_requires = 
     apache-airflow >= 2.5.3
+    apache-airflow-providers-http >= 4.0.0
+    requests >= 2.26.0
 
 [options.packages.find]
 exclude= *test*


### PR DESCRIPTION
- Add `RudderstackRETLOperator` for triggering RETL syncs
- updated required dependencies. `requests` is a new addition. airflow http is missed previously and added it now. Versions added as per the [constraints](https://raw.githubusercontent.com/apache/airflow/constraints-2.5.3/constraints-3.7.txt)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
