### PR TITLE
chore: deps upgrade and get rid of requirements.txt

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
         python-version: 3.11
     - name: Install dependencies
       run: |
-        pip3 install -r requirements.txt
+        pip3 install .
     - name: Test with pytest
       run: |
         pip3 install pytest-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
 requires = [
-    "setuptools >= 70.0",
+    "setuptools >= 80.4.0",
     "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "rudderstack-airflow-provider"
-version = "2.3.0"
+version = "2.4.0"
 readme = "README.md"
 license = {file = "LICENSE"}
 description = "Apache airflow provider for managing Reverse ETL syncs and Profiles runs in RudderStack."
@@ -16,13 +16,15 @@ classifiers = [
     "Framework :: Apache Airflow :: Provider",
 ]
 dependencies = [
-    "apache-airflow",
-    "pytest",
-    "requests",
-    "responses",
-    "setuptools"
+    "apache-airflow>=2.10.0",
+    "pytest>=7.3.1",
+    "requests>=2.32.3",
+    "responses>=0.25.0",
+    "setuptools>=80.4.0",
+    "zipp>=3.19.1",
+    "ruff>=0.6.8"
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.12"
 
 [tool.setuptools.packages.find]
 exclude = ["*test*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "zipp>=3.19.1",
     "ruff>=0.6.8"
 ]
-requires-python = ">= 3.12"
+requires-python = ">= 3.11"
 
 [tool.setuptools.packages.find]
 exclude = ["*test*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Framework :: Apache Airflow :: Provider",
 ]
 dependencies = [
-    "apache-airflow>=2.10.0<=2.10.5",
+    "apache-airflow>=2.10.0,<=2.10.5",
     "pytest>=7.3.1",
     "requests>=2.32.3",
     "responses>=0.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools >= 80.4.0",
+    "setuptools >= 80.0.0",
     "wheel"]
 build-backend = "setuptools.build_meta"
 
@@ -16,11 +16,11 @@ classifiers = [
     "Framework :: Apache Airflow :: Provider",
 ]
 dependencies = [
-    "apache-airflow>=2.10.0",
+    "apache-airflow>=2.10.0<=2.10.5",
     "pytest>=7.3.1",
     "requests>=2.32.3",
     "responses>=0.25.0",
-    "setuptools>=80.4.0",
+    "setuptools>=80.0.0",
     "zipp>=3.19.1",
     "ruff>=0.6.8"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-apache-airflow == 2.10.0
-requests == 2.32.3
-setuptools == 70.0.0
-pytest==7.3.1
-ruff==0.6.8

--- a/rudder_airflow_provider/operators/rudderstack.py
+++ b/rudder_airflow_provider/operators/rudderstack.py
@@ -14,7 +14,7 @@ RUDDERTACK_DEFAULT_CONNECTION_ID = "rudderstack_default"
 
 
 class RudderstackRETLOperator(baseoperator.BaseOperator):
-    template_fields = ("retl_connection_id")
+    template_fields = ("retl_connection_id",)
 
     """
         Rudderstack operator for RETL connnections
@@ -121,7 +121,7 @@ class RudderstackProfilesOperator(baseoperator.BaseOperator):
             rs_profiles_hook.poll_profile_run(self.profile_id, profile_run_id)
 
 class RudderstackETLOperator(baseoperator.BaseOperator):
-    template_fields = ("etl_source_id")
+    template_fields = ("etl_source_id",)
 
     """
         Rudderstack operator for ETL


### PR DESCRIPTION
**Fixes** # (*issue*)

1. Get rid of requirements.txt, snyk vulnerability scan keeps showing false vulnerabilities somehow. For any local development if its needed, easy to generate.
2. Upgrade for setuptools https://security.snyk.io/vuln/SNYK-PYTHON-SETUPTOOLS-9964606
3. Pinned versions for other dependencies as well.
4. New airflow 3.x version has some minor changes we need to handle. Keeping airflow pin version within 2.10 range.

part of [WAR-650](https://linear.app/rudderstack/issue/WAR-650/snyk-vulnerability-rudderstack-airflow-and-dagster-lib)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
