### PR TITLE
chore: add airflow versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Framework :: Apache Airflow :: Provider",
 ]
 dependencies = [
-    "apache-airflow>=2.10.0,<=2.10.5",
+    "apache-airflow>=2.10.0,<=3.0.1",
     "pytest>=7.3.1",
     "requests>=2.32.3",
     "responses>=0.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Framework :: Apache Airflow :: Provider",
 ]
 dependencies = [
-    "apache-airflow>=2.10.0,<=3.0.1",
+    "apache-airflow>=2.10.0",
     "apache-airflow-providers-http>=5.0.0",
     "pytest>=7.3.1",
     "requests>=2.32.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "apache-airflow>=2.10.0,<=3.0.1",
+    "apache-airflow-providers-http>=5.0.0",
     "pytest>=7.3.1",
     "requests>=2.32.3",
     "responses>=0.25.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rudderstack-airflow-provider"
-version = "2.4.0"
+version = "2.4.1"
 readme = "README.md"
 license = {file = "LICENSE"}
 description = "Apache airflow provider for managing Reverse ETL syncs and Profiles runs in RudderStack."


### PR DESCRIPTION
**Fixes** # (*issue*)

Removed upper limit for airflow version. Added apache-airflow-providers-http explicitly in dependency. Seems for higher versions of apache airflow, this does not get installed and needs to be added explictly. 

resolves WAR-702

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
